### PR TITLE
Fixes issue #2 and issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Normal Google Map infowindow behavior is supported, including moving the window 
 
 The element is meant to be fully composable so you can have anything inside, even neon-animated-pages, if you want.
 
+## Referencing Requirements
+
+The element is written in typescript and requires `polymer-ts`, which should come right after your `polymer` reference.
+```
+<script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+<link rel-"import" href="bower_components/polymer/polymer.html" />
+<link rel-"import" href="bower_components/polymer-ts/polymer-ts.html" />
+<link rel-"import" href="bower_components/paper-map-info/paper-map-info.html" />
+```
+Of course, using the path to bower_components that applies to your project.
+
 ## Styling
 
 You can customize the paper-material background using the `--paper-map-info-mixin`.  You can customize the style of the beak (pointer from the card to the pin) with `--paper-map-info-beak-mixin`. Or even replace the default beak entirely with:

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "google-map": "GoogleWebComponents/google-map#^1.1.10",
     "polymer-ts": "^0.1.26",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "paper-material": "^1.0.6"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "test",
     "tests"
   ],
-  "dependencies": {
+  "dependencies": { 
     "polymer": "Polymer/polymer#^1.2.0",
     "google-map": "GoogleWebComponents/google-map#^1.1.10",
     "polymer-ts": "^0.1.26",

--- a/bower.json
+++ b/bower.json
@@ -33,5 +33,6 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "web-component-tester": "^4.0.0",
     "syntax-highlight": "^1.0.0"
-  }
+  },
+  "version": "1.0.2"
 }

--- a/paper-map-info.html
+++ b/paper-map-info.html
@@ -41,6 +41,8 @@ _startFriendChat: function(e) {
 
 -->
 <script src="../underscore/underscore.js"></script>
+<link rel="import" href="../polymer/polymer.html" />
+<link rel="import" href="../polymer-ts/polymer-ts.html" />
 <link rel="import" href="../paper-material/paper-material.html" />
 <link rel="import" href="../iron-icon/iron-icon.html" />
 


### PR DESCRIPTION
Fixes issues:
[polymer not defined error #2 ](https://github.com/mlisook/paper-map-info/issues/2)
[missing requirement of 'paper-material' in bower.json #3](https://github.com/mlisook/paper-map-info/issues/3)

There was a missing dependency for `paper-material` in bower.json.

The README.md did not include referencing instructions.  Since the element uses typescript there is a requirement  to include `polymer-ts`.  This should have been documented on the README.md page.
